### PR TITLE
Fixes for page breaks from migration to developer.riscv.org

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,14 +11,14 @@ const config: Config = {
   staticDirectories: ['antora/build/', 'static'],
 
   // Set the production url of your site here
-  url: 'https://docs.riscv.org',
+  url: 'https://developer.riscv.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs.riscv.org/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'riscv-admin', // Usually your GitHub org/user name.
+  organizationName: 'riscv', // Usually your GitHub org/user name.
   projectName: 'docs.riscv.org', // Usually your repo name.
   deploymentBranch: 'gh-pages',
 

--- a/src/pages/isa.tsx
+++ b/src/pages/isa.tsx
@@ -104,7 +104,7 @@ export default function Home(): ReactNode {
   return (
     <LayoutISA>
     <iframe 
-      src={`${siteConfig.baseUrl}/site/isa/index.html`}  
+      src={`${siteConfig.baseUrl}site/isa/index.html`}  
       title="Description" 
       style={{height: '96vh', width: '100vw'}} />
     </LayoutISA>


### PR DESCRIPTION
various quick fixes to unbreak the site post migration